### PR TITLE
👷 update github workflows

### DIFF
--- a/.devcontainer/Containerfile
+++ b/.devcontainer/Containerfile
@@ -1,5 +1,5 @@
 FROM rust:bookworm
-
+#
 ARG VERSION="stable"
 ARG FLUTTER_URL="https://github.com/flutter/flutter"
 ARG ANDROID_SDK_TOOLS_VERSION=9477386

--- a/.github/workflows/push_container.yaml
+++ b/.github/workflows/push_container.yaml
@@ -1,0 +1,28 @@
+name: Push container
+on:
+  push:
+    branches:
+      - development
+      - master
+    paths:
+      - '.devcontainer/Containerfile'
+
+jobs:
+  push:
+    name: Push container image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          token: ${{secrets.TOKEN}}
+      - name: 'Login to GitHub Container Registry'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{github.repository_owner}}
+          password: ${{secrets.TOKEN}}
+      - name: Build and push Docker image
+        run: |
+          docker build . -f ./.devcontainer/Containerfile -t ghcr.io/${{ github.repository_owner }}/7tv4wa-dev:${{ github.head_ref || github.ref_name }} -t ghcr.io/${{ github.repository_owner }}/7tv4wa-dev:latest
+          docker push ghcr.io/${{ github.repository_owner }}/7tv4wa-dev --all-tags

--- a/.github/workflows/test_build.yaml
+++ b/.github/workflows/test_build.yaml
@@ -1,17 +1,17 @@
-name: Release
+name: Build
 on:
-  push:
-    branches:
-      - master
+  pull_request:
+    types:
+      - opened
+      - synchronize
 
 permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+  contents: read
+  pull-requests: read
 
 jobs:
-  release:
-    name: Create release
+  build:
+    name: Build APK
     runs-on: ubuntu-latest
     container:
       image: >-
@@ -34,5 +34,3 @@ jobs:
           token: ${{secrets.TOKEN}}
       - name: Build apk
         run: chmod +x .github/workflows/*.sh && .github/workflows/build.sh
-      - name: Publish release
-        run: git config --global --add safe.directory '*' && .github/workflows/publish.sh


### PR DESCRIPTION
 add a build check for all pull requests to and automatically build
 and push the containerfile to the ghcr on all pushs to development
 and master. Other pipelines do not wait for the container to be
 pushed which means that they may have to be manually restarted if
 they fail due to an old container image.